### PR TITLE
Add declarations to quiet warnings

### DIFF
--- a/tools/las2ght.c
+++ b/tools/las2ght.c
@@ -31,6 +31,12 @@
 static char *ght_file_template = "%s-%d-%s.ght";
 static char *xml_file_template = "%s-%d-%s.ght.xml";
 
+/* declarations */
+void ght_init(void);
+void ght_info(const char *fmt, ...);
+void ght_warn(const char *fmt, ...);
+void ght_error(const char *fmt, ...);
+
 typedef enum
 {
     LL_INTENSITY = 0,
@@ -180,7 +186,7 @@ l2g_config_free(Las2GhtConfig *config)
     }
 }
 
-l2g_state_free(Las2GhtState *state)
+static void l2g_state_free(Las2GhtState *state)
 {
     if ( state->header )
     {


### PR DESCRIPTION
This patch removes some implicit declarations in las2git.c that were causing warnings for clang-503.0.40. Also  added a missing type specifier for `l2g_state_free`.
